### PR TITLE
Fix dev server to use esbuild context API

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -8,36 +8,37 @@ const assetFile = resolve(distDir, 'assets/main.js');
 mkdirSync(resolve(distDir, 'assets'), { recursive: true });
 copyFileSync(resolve('index.html'), resolve(distDir, 'index.html'));
 
-esbuild
-  .serve(
-    {
-      servedir: distDir,
-      port: 5173,
-      host: '0.0.0.0'
-    },
-    {
-      entryPoints: [resolve('src/main.tsx')],
-      outfile: assetFile,
-      bundle: true,
-      sourcemap: true,
-      format: 'esm',
-      jsx: 'automatic',
-      alias: {
-        '@': resolve('src')
-      },
-      loader: {
-        '.ts': 'ts',
-        '.tsx': 'tsx'
-      },
-      define: {
-        'process.env.NODE_ENV': JSON.stringify('development')
-      }
-    }
-  )
-  .then(({ host, port }) => {
-    console.log(`Dev server running at http://${host}:${port}`);
-  })
-  .catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
+const buildOptions = {
+  entryPoints: [resolve('src/main.tsx')],
+  outfile: assetFile,
+  bundle: true,
+  sourcemap: true,
+  format: 'esm',
+  jsx: 'automatic',
+  alias: {
+    '@': resolve('src')
+  },
+  loader: {
+    '.ts': 'ts',
+    '.tsx': 'tsx'
+  },
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('development')
+  }
+};
+
+const serveOptions = {
+  servedir: distDir,
+  port: 5173,
+  host: '0.0.0.0'
+};
+
+try {
+  const context = await esbuild.context(buildOptions);
+  await context.watch();
+  const { host, port } = await context.serve(serveOptions);
+  console.log(`Dev server running at http://${host}:${port}`);
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- replace the deprecated `esbuild.serve` call with the modern context API to start the dev server without runtime errors

## Testing
- `npm run dev` *(fails: dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da18f64f608330831548e9e63590e9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces deprecated `esbuild.serve` with the context API, adding `watch()` and `serve()` flow in `scripts/dev.mjs`.
> 
> - **Dev tooling**:
>   - **`scripts/dev.mjs`**:
>     - Replace `esbuild.serve` with `esbuild.context` + `watch()` and `serve()`.
>     - Extract `buildOptions` and `serveOptions` objects.
>     - Use `try/catch` with async/await; logs server URL from `context.serve()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e698e25bd3aef7ad26e86460c7460375dbb8911a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->