### PR TITLE
Improve viewport styling and interaction controls

### DIFF
--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -19,6 +19,10 @@ const Viewport = () => {
   const pushHistory = useSceneStore((state) => state.pushHistory);
   const selectedId = useSceneStore((state) => state.selectedId);
   const transformMode = useSceneStore((state) => state.transformMode);
+  const helpers = useSceneStore((state) => state.helpers);
+  const toggleHelper = useSceneStore((state) => state.toggleHelper);
+  const focusSelected = useSceneStore((state) => state.focusSelected);
+  const resetCamera = useSceneStore((state) => state.resetCamera);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -28,6 +32,8 @@ const Viewport = () => {
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type = THREE.PCFSoftShadowMap;
     renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
     container.appendChild(renderer.domElement);
 
     const controls = new OrbitControls(camera, renderer.domElement);
@@ -105,10 +111,17 @@ const Viewport = () => {
 
     renderer.domElement.addEventListener('pointerdown', onPointerDown);
 
+    const onDoubleClick = () => {
+      focusSelected();
+    };
+
+    renderer.domElement.addEventListener('dblclick', onDoubleClick);
+
     return () => {
       cancelAnimationFrame(animationFrame);
       resizeObserver.disconnect();
       renderer.domElement.removeEventListener('pointerdown', onPointerDown);
+      renderer.domElement.removeEventListener('dblclick', onDoubleClick);
       transformControls.detach();
       scene.remove(transformControls);
       renderer.dispose();
@@ -136,7 +149,31 @@ const Viewport = () => {
     }
   }, [scene, selectedId]);
 
-  return <div ref={containerRef} className="viewport-canvas" />;
+  return (
+    <div ref={containerRef} className="viewport-canvas">
+      <div className="viewport-overlay">
+        <div className="viewport-overlay-group">
+          <button type="button" onClick={resetCamera}>
+            重置视角
+          </button>
+          <button type="button" onClick={focusSelected} disabled={!selectedId}>
+            对齐选中
+          </button>
+        </div>
+        <div className="viewport-overlay-group">
+          <button type="button" className={helpers.grid ? 'active' : ''} onClick={() => toggleHelper('grid')}>
+            网格
+          </button>
+          <button type="button" className={helpers.axes ? 'active' : ''} onClick={() => toggleHelper('axes')}>
+            坐标轴
+          </button>
+        </div>
+      </div>
+      <div className="viewport-hint">
+        <span>拖拽旋转 · 右键平移 · 滚轮缩放</span>
+      </div>
+    </div>
+  );
 };
 
 export default Viewport;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2,15 +2,18 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  background: radial-gradient(circle at top left, #1a2231 0%, #0b111a 55%, #05070a 100%);
 }
 
 .workspace {
   flex: 1;
   display: grid;
   grid-template-columns: minmax(220px, 280px) 1fr minmax(260px, 320px);
+  grid-template-rows: minmax(0, 1fr);
   gap: 12px;
-  padding: 12px;
-  background: linear-gradient(180deg, #0f141a 0%, #0b1016 100%);
+  padding: 18px 20px 22px;
+  background: rgba(8, 12, 20, 0.55);
+  backdrop-filter: blur(24px);
 }
 
 .sidebar {
@@ -18,23 +21,27 @@
   flex-direction: column;
   gap: 12px;
   overflow: hidden;
+  min-height: 0;
 }
 
 .sidebar > * {
-  background: rgba(19, 25, 34, 0.9);
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  background: rgba(16, 22, 33, 0.92);
+  border-radius: 14px;
+  border: 1px solid rgba(92, 140, 255, 0.08);
+  box-shadow: 0 18px 50px rgba(7, 13, 22, 0.45);
   overflow: hidden;
 }
 
 .viewport-panel {
   position: relative;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 20px 40px rgba(0, 0, 0, 0.4);
-  background: radial-gradient(circle at top, rgba(60, 86, 130, 0.3), rgba(10, 14, 21, 0.95));
+  display: flex;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(104, 149, 255, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 24px 60px rgba(0, 0, 0, 0.55);
+  background: radial-gradient(circle at 20% 20%, rgba(68, 108, 199, 0.28), rgba(6, 10, 18, 0.92));
   overflow: hidden;
+  min-height: 0;
 }
 
 .panel {
@@ -96,19 +103,19 @@
   align-items: center;
   padding: 12px 18px;
   gap: 12px;
-  background: rgba(10, 14, 20, 0.95);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+  background: rgba(8, 12, 20, 0.9);
+  border-bottom: 1px solid rgba(86, 142, 255, 0.12);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
 }
 
 .toolbar-group {
   display: flex;
   align-items: center;
   gap: 8px;
-  background: rgba(25, 32, 44, 0.8);
-  padding: 8px 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(20, 29, 45, 0.85);
+  padding: 8px 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(104, 149, 255, 0.14);
 }
 
 .toolbar button,
@@ -126,14 +133,14 @@
 
 .toolbar button:hover,
 .toolbar label:hover {
-  background: rgba(88, 130, 201, 0.2);
-  color: #bcd4ff;
+  background: rgba(86, 142, 255, 0.28);
+  color: #d2e3ff;
 }
 
 .toolbar button.active {
-  background: linear-gradient(135deg, rgba(86, 140, 255, 0.7), rgba(74, 190, 255, 0.7));
-  color: #0b111c;
-  box-shadow: 0 6px 18px rgba(85, 140, 255, 0.35);
+  background: linear-gradient(135deg, rgba(86, 140, 255, 0.85), rgba(74, 190, 255, 0.7));
+  color: #050a15;
+  box-shadow: 0 8px 22px rgba(86, 140, 255, 0.4);
 }
 
 .file-input {
@@ -141,27 +148,67 @@
 }
 
 .viewport-canvas {
-  position: absolute;
-  inset: 0;
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: stretch;
 }
 
 .viewport-overlay {
   position: absolute;
-  bottom: 12px;
-  right: 12px;
+  bottom: 16px;
+  right: 16px;
   display: flex;
+  flex-direction: column;
   gap: 8px;
+  pointer-events: none;
 }
 
 .viewport-overlay button {
-  background: rgba(14, 20, 30, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  color: rgba(255, 255, 255, 0.8);
-  padding: 6px 10px;
-  border-radius: 8px;
+  background: rgba(8, 12, 20, 0.82);
+  border: 1px solid rgba(118, 165, 255, 0.22);
+  color: rgba(255, 255, 255, 0.82);
+  padding: 6px 14px;
+  border-radius: 999px;
   font-size: 12px;
-  text-transform: uppercase;
   letter-spacing: 0.06em;
+  pointer-events: auto;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.viewport-overlay button:hover {
+  background: rgba(86, 142, 255, 0.25);
+  border-color: rgba(118, 165, 255, 0.4);
+}
+
+.viewport-overlay button.active {
+  background: linear-gradient(135deg, rgba(86, 140, 255, 0.85), rgba(74, 190, 255, 0.7));
+  color: #050a15;
+  border-color: transparent;
+}
+
+.viewport-overlay button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.viewport-overlay-group {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.viewport-hint {
+  position: absolute;
+  left: 20px;
+  bottom: 20px;
+  padding: 8px 14px;
+  border-radius: 12px;
+  background: rgba(8, 12, 20, 0.72);
+  border: 1px solid rgba(118, 165, 255, 0.2);
+  color: rgba(225, 233, 255, 0.72);
+  font-size: 12px;
+  letter-spacing: 0.05em;
 }
 
 .hierarchy-tree {


### PR DESCRIPTION
## Summary
- refresh the workspace, toolbar, and viewport styling for a cleaner three-column layout
- add viewport overlay controls for camera reset, focus, and helper toggles with usage hints
- expose focus and reset camera actions in the scene store to support new interactions

## Testing
- npm install *(fails: 403 Forbidden fetching esbuild from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68da1b943f4c83309424e2db1be68384

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a viewport overlay with camera reset/focus and helper toggles, double‑click focus, and refreshed workspace/viewport styling.
> 
> - **Viewport UI/Interactions**:
>   - Add overlay controls in `src/components/Viewport.tsx` for `resetCamera`, `focusSelected`, and toggling `helpers` (`grid`, `axes`), plus on‑canvas usage hint.
>   - Enable double‑click on canvas to trigger `focusSelected`.
>   - Ensure renderer canvas fills container via inline `style`.
> - **State/Scene Store** (`src/state/useSceneStore.ts`):
>   - Add `focusSelected()` to frame selected object and reposition camera/orbit target.
>   - Add `resetCamera()` to restore default camera position/target.
>   - Integrate with existing `toggleHelper` state.
> - **Styling** (`src/styles/app.css`):
>   - Refresh app/workspace/toolbar/viewport aesthetics (gradients, borders, shadows, blur) and layout tweaks.
>   - Rework `.viewport-canvas` to flex container; style overlay groups, active/disabled button states, and add `.viewport-hint`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d5b18d9f970e5c26eaf0faf0a8054bef9de2870. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->